### PR TITLE
Show detailed code style errors in console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ CHANGELOG for PHP CS Fixer Action
 
 This file contains changelogs for stable releases only.
 
+Changelog for v1.0.2
+--------------------
+
+* feature: Show detailed code style errors in the Action console (files, fixers and diffs) when violations are found. [#9](https://github.com/ale94lko/php-cs-fixer-action/issues/9)
+
 Changelog for v1.0.1
 --------------------
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 > A github action to fix PHP Coding Standards using [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer).
 
+When style violations are found, the Action fails and prints a detailed console report (affected files, applied fixers and diffs) so you know exactly what to fix.
+
 ## Requirements
 
 - Be sure to have set the following before using the action
@@ -25,7 +27,7 @@
 - Include the following in your action:
   ```yaml
   - name: php-cs-fixer
-    uses: ale94lko/php-cs-fixer-action@v1.0.1
+    uses: ale94lko/php-cs-fixer-action@v1.0.2
   ```
 
 ## Parameters
@@ -49,13 +51,13 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: PHP Code Style
-        uses: ale94lko/php-cs-fixer-action@v1.0.1
+        uses: ale94lko/php-cs-fixer-action@v1.0.2
 ```
 
 ### Simple use with `php-cs-fixer-version`
 ```diff
   - name: PHP Code Style
-    uses: ale94lko/php-cs-fixer-action@v1.0.1
+    uses: ale94lko/php-cs-fixer-action@v1.0.2
 +   with:
 +     php-cs-fixer-version: v3.9.4
 ```
@@ -63,7 +65,7 @@ jobs:
 ### Simple use with `rules-version`
 ```diff
   - name: PHP Code Style
-    uses: ale94lko/php-cs-fixer-action@v1.0.1
+    uses: ale94lko/php-cs-fixer-action@v1.0.2
 +   with:
 +     rules-version: v1.0.1
 ```
@@ -71,7 +73,7 @@ jobs:
 ### Simple use with `use-full-rules`
 ```diff
   - name: PHP Code Style
-    uses: ale94lko/php-cs-fixer-action@v1.0.1
+    uses: ale94lko/php-cs-fixer-action@v1.0.2
 +   with:
 +     use-full-rules: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -44,5 +44,25 @@ runs:
       id: php-cs-fixer
       shell: bash
       run: |
-        ./php-cs-fixer fix --verbose --allow-risky=yes --dry-run --format=txt > ./result.txt
-        echo "::set-output name=result::$(cat ./result.txt)"
+        set +e
+        ./php-cs-fixer fix \
+          --verbose \
+          --diff \
+          --show-progress=none \
+          --allow-risky=yes \
+          --dry-run \
+          --format=txt \
+          2>&1 | tee ./result.txt
+        exit_code=${PIPESTATUS[0]}
+        set -e
+
+        {
+          echo "result<<PHP_CS_FIXER_EOF"
+          cat ./result.txt
+          echo "PHP_CS_FIXER_EOF"
+        } >> "$GITHUB_OUTPUT"
+
+        if [ "$exit_code" -ne 0 ]; then
+          echo "::error::PHP CS Fixer found coding standard violations. See the detailed report above for files, fixers and diffs."
+          exit "$exit_code"
+        fi


### PR DESCRIPTION
## Summary
- Print the full PHP CS Fixer report (files, fixers and diffs) in the Action log when violations are found.
- Preserve the exit code so the job still fails, while always exposing the details PR authors need.
- Replace deprecated `::set-output` with `GITHUB_OUTPUT`.

Closes #9

## Test plan
- [ ] Run the Action against a repo with intentional style violations and confirm the console shows file paths, fixers and diffs.
- [ ] Run the Action against a clean repo and confirm it still passes.
- [ ] Confirm the `code-style-result` output is populated on both success and failure paths.

Made with [Cursor](https://cursor.com)