### PR TITLE
Fix CI on PHP 8.3 GitHub runners

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -4,11 +4,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: PHP Code Style
-        uses: ale94lko/php-cs-fixer-action@v1.0.1
+        uses: ./
         with:
-          php-cs-fixer-version: v3.9.4
+          php-cs-fixer-version: v3.95.21
           rules-version: v1.0.1
           use-full-rules: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Changelog for v1.0.2
 --------------------
 
 * feature: Show detailed code style errors in the Action console (files, fixers and diffs) when violations are found. [#9](https://github.com/ale94lko/php-cs-fixer-action/issues/9)
+* fix: Bump default php-cs-fixer to `v3.95.21` and set `PHP_CS_FIXER_IGNORE_ENV` so the Action works on current GitHub runners (PHP 8.3+).
+* chore: Point the self-test workflow at the local Action and update `actions/checkout` to v4.
 
 Changelog for v1.0.1
 --------------------

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   </a>
 </p>
 
-> A github action to fix PHP Coding Standards using [php-cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer).
+> A github action to fix PHP Coding Standards using [php-cs-fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer).
 
 When style violations are found, the Action fails and prints a detailed console report (affected files, applied fixers and diffs) so you know exactly what to fix.
 
@@ -19,7 +19,7 @@ When style violations are found, the Action fails and prints a detailed console 
 
 - Be sure to have set the following before using the action
   ```yaml
-  - uses: actions/checkout@v2
+  - uses: actions/checkout@v4
   ```
 
 ## Setup
@@ -34,7 +34,7 @@ When style violations are found, the Action fails and prints a detailed console 
 
 | Name | Description | Required | Default | Values |
 |----------|:----------:|:----------:|:----------:|:----------:|
-| php-cs-fixer-version | Version of php-cs-fixer to download | `false` | `v3.9.4` | v`X.X.X` |
+| php-cs-fixer-version | Version of php-cs-fixer to download | `false` | `v3.95.21` | v`X.X.X` |
 | rules-version | Version of rules to check from [php-cs-fixer-rules](https://github.com/ale94lko/php-cs-fixer-rules) | `false` | `v1.0.1` | v`X.X.X` |
 | use-full-rules | Whether to use the full rules package or the minimal one | `false` | `true` | `true` OR `false` |
 
@@ -48,7 +48,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: PHP Code Style
         uses: ale94lko/php-cs-fixer-action@v1.0.2
@@ -59,7 +59,7 @@ jobs:
   - name: PHP Code Style
     uses: ale94lko/php-cs-fixer-action@v1.0.2
 +   with:
-+     php-cs-fixer-version: v3.9.4
++     php-cs-fixer-version: v3.95.21
 ```
 
 ### Simple use with `rules-version`

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   php-cs-fixer-version:
     description: 'Version of php-cs-fixer to download'
     required: false
-    default: 'v3.9.4'
+    default: 'v3.95.21'
   rules-version:
     description: 'Version of rules to check'
     required: false
@@ -27,7 +27,7 @@ runs:
     - name: Download php-cs-fixer
       shell: bash
       run: |
-        curl --fail -L https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/${{ inputs.php-cs-fixer-version }}/php-cs-fixer.phar -o php-cs-fixer
+        curl --fail -L https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/${{ inputs.php-cs-fixer-version }}/php-cs-fixer.phar -o php-cs-fixer
         chmod a+x php-cs-fixer
 
     - name: Download PHP CS Fixer rules full
@@ -43,6 +43,8 @@ runs:
     - name: Run PHP CS Fixer
       id: php-cs-fixer
       shell: bash
+      env:
+        PHP_CS_FIXER_IGNORE_ENV: '1'
       run: |
         set +e
         ./php-cs-fixer fix \


### PR DESCRIPTION
## Summary
- The failed `Fix code styles` run exited because php-cs-fixer `v3.9.4` rejects PHP 8.3 on `ubuntu-latest`.
- Bump the default php-cs-fixer version to `v3.95.21` and set `PHP_CS_FIXER_IGNORE_ENV`.
- Point the self-test workflow at `uses: ./` (so PRs exercise this repo's Action) and update `actions/checkout` to v4.

## Test plan
- [x] Confirm the `Fix code styles` workflow passes on this PR.
- [x] Confirm the Action still prints detailed style errors when violations exist.

Made with [Cursor](https://cursor.com)