### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -1,5 +1,7 @@
 name: Fix code styles
 on: [pull_request]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ale94lko/php-cs-fixer-action/security/code-scanning/3](https://github.com/ale94lko/php-cs-fixer-action/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged by default.  
Best fix here (without changing functionality) is to add workflow-level permissions directly under `on`, before `jobs`, with:

- `contents: read`

This is sufficient for `actions/checkout@v4` and typical read-only style checks, and it satisfies the CodeQL rule while keeping behavior minimal and secure.  
Only `.github/workflows/code_review.yml` needs editing; no imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
